### PR TITLE
Reverse Words Ruby implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,26 @@ dry:
   restore_shards_cache: &restore_shards_cache
     # Use {{ checksum "shard.yml" }} if developing a shard instead of an app
     keys:
-      - shards-cache-v26-{{ .Branch }}-{{ checksum "shard.lock" }}
-      - shards-cache-v26-{{ .Branch }}
-      - shards-cache-v26
+      - shards-cache-v1-{{ .Branch }}-{{ checksum "shard.lock" }}
+      - shards-cache-v1-{{ .Branch }}
+      - shards-cache-v1
 
   save_shards_cache: &save_shards_cache
     # Use {{ checksum "shard.yml" }} if developing a shard instead of an app
     key: shards-cache-v1-{{ .Branch }}-{{ checksum "shard.lock" }}
     paths:
-      - ./shards-cache
+      - shards-cache
+
+  restore_bundle_cache: &restore_bundle_cache
+    keys:
+      - bundle-cache-v1-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+      - bundle-cache-v1-{{ .Branch }}
+      - bundle-cache-v1
+
+  save_bundle_cache: &save_bundle_cache
+    key: bundle-cache-v1-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+    paths:
+      - vendor/bundle
 
 jobs:
   golang:
@@ -31,23 +42,40 @@ jobs:
       - run: go test -bench=. ./benchmarks/... -v
       - store_test_results:
           path: /tmp/test-results
+
   ruby:
     docker:
       - image: circleci/ruby:2.6.0-preview3
+        environment:
+          RUBYOPT: "--enable-frozen-string-literal --jit"
+
     steps:
       - checkout
-      - run: ruby -I. -I./algorithms/problems/codewars  algorithms/problems/codewars/sudoku_test.rb
+
+      - restore_cache: *restore_bundle_cache
+      - run: bundle install --path vendor/bundle
+      - save_cache: *save_bundle_cache
+
+      - run:
+          command: bundle exec rubocop -c .rubocop.yml -L
+          background: true
+      - run: ruby algorithms/problems/codewars/sudoku_test.rb
+      - run: ruby algorithms/problems/interviewcake/reverse_words_test.rb
+
   crystal:
     # https://crystal-lang.org/2018/09/04/using-circleci-2.0-for-your-crystal-projects.html
     docker:
-      - image: crystallang/crystal:0.27.0
+      - image: crystallang/crystal:latest
     steps:
       - run: crystal --version
       - checkout
+
       - restore_cache: *restore_shards_cache
       - run: shards install
       - save_cache: *save_shards_cache
+
       - run: crystal run algorithms/list/node_test.cr -- --verbose
+
   distribusion:
     working_directory: ~/samples/distribusion
     docker:
@@ -57,14 +85,11 @@ jobs:
     steps:
       - checkout:
           path: ~/samples
-      - restore_cache:
-          key: dependency-cache-{{ checksum "Gemfile.lock" }}
+      - restore_cache: *restore_bundle_cache
       - run: bundle install --path vendor/bundle
-      - save_cache:
-          key: dependency-cache-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
-      - run: bundle exec rubocop -c .rubocop.yml
+      - save_cache: *save_bundle_cache
+
+      - run: bundle exec rubocop -P -c .rubocop.yml
       - run: bundle exec rake test
       - run: bundle exec ruby --enable-frozen-string-literal ./bin/local -v -s all -p $DISTRIBUSION_PASSPHRASE | sed s/"${DISTRIBUSION_PASSPHRASE}"/xxx/g
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,17 @@
+AllCops:
+  DisplayCopNames: true
+  TargetRubyVersion: 2.5
+  Exclude:
+    - bin/*
+    - vendor/bundle/**/*
+
+Metrics/LineLength:
+  Max: 110
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/ClassLength:
+  Exclude:
+    - lib/distribusion/route.rb
+    - test/**/*_test.rb

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'rubocop'
+gem 'rubocop', github: 'rubocop-hq/rubocop'
+gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,27 @@
-GEM
-  remote: https://rubygems.org/
+GIT
+  remote: https://github.com/rubocop-hq/rubocop
+  revision: 548a39a441c0959e898fa8ebfe9d361237a1c331
   specs:
-    ast (2.4.0)
-    jaro_winkler (1.5.1)
-    parallel (1.12.1)
-    parser (2.5.1.2)
-      ast (~> 2.4.0)
-    powerpack (0.1.2)
-    rainbow (3.0.0)
-    rubocop (0.58.2)
+    rubocop (0.61.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
+      unicode-display_width (~> 1.4.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.0)
+    jaro_winkler (1.5.1)
+    minitest (5.11.3)
+    parallel (1.12.1)
+    parser (2.5.3.0)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
+    rainbow (3.0.0)
     ruby-progressbar (1.10.0)
     unicode-display_width (1.4.0)
 
@@ -23,7 +29,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rubocop
+  minitest
+  rubocop!
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/algorithms/problems/codewars/.ruby-version
+++ b/algorithms/problems/codewars/.ruby-version
@@ -1,1 +1,1 @@
-2.6.0-preview2
+2.6.0-preview3

--- a/algorithms/problems/interviewcake/reverse_words.rb
+++ b/algorithms/problems/interviewcake/reverse_words.rb
@@ -1,0 +1,52 @@
+=begin
+You're working on a secret team solving coded transmissions.
+
+Your team is scrambling to decipher a recent message, worried it's a plot to break into a major European National Cake Vault. The message has been mostly deciphered, but all the words are backward! Your colleagues have handed off the last step to you.
+
+Write a method `reverse_words()` that takes a message as a string and reverses the order of the words in place.
+
+For example:
+
+    message = 'cake pound steal'
+    reverse_words(message)
+    puts message
+    # prints: 'steal pound cake'
+
+When writing your method, assume the message contains only letters and spaces, and all words are separated by one space.
+=end
+
+def reverse_words(str)
+  return str if str == nil || str == ''
+
+  n = str.size
+  word_start = 0
+  word_finish = 0
+
+  while word_finish < n
+    if str[word_finish] != ' '
+      word_finish += 1
+      next
+    end
+
+    reverse(str, word_start, word_finish-1)
+    word_finish += 1
+    word_start = word_finish
+  end
+
+  reverse(str, word_start, word_finish-1)
+  reverse(str, 0, n-1)
+  str
+end
+
+def reverse(str, start, finish)
+  return if finish <= start
+  i = start
+  j = finish
+  while i < j
+    t = str[i]
+    str[i] = str[j]
+    str[j] = t
+    i += 1
+    j -= 1
+  end
+end

--- a/algorithms/problems/interviewcake/reverse_words_test.rb
+++ b/algorithms/problems/interviewcake/reverse_words_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: false
+
+require 'minitest/autorun'
+
+require_relative 'reverse_words.rb'
+
+class ReverseWordsTest < Minitest::Test
+  def test_with_nil
+    assert_nil reverse_words(nil)
+  end
+
+  def test_with_empty
+    assert_equal '', reverse_words('')
+  end
+
+  def test_with_one_word
+    assert_equal 'one', reverse_words('one')
+  end
+
+  def test_with_multiple_one_letter_words
+    assert_equal 'b a', reverse_words('a b')
+  end
+
+  def test_with_multiple_two_letters_words
+    assert_equal 'cd ab', reverse_words('ab cd')
+  end
+
+  def test_with_two_words
+    assert_equal 'two one', reverse_words('one two')
+  end
+
+  def test_with_two_words_and_trailing_space
+    assert_equal 'two one ', reverse_words(' one two')
+  end
+
+  def test_with_two_words_and_head_trailing_space
+    assert_equal ' two one', reverse_words('one two ')
+  end
+
+  def test_with_two_words_and_trailing_spaces
+    assert_equal ' two one ', reverse_words(' one two ')
+  end
+
+  def test_inplace
+    subject = ' one two '
+    result = reverse_words(subject)
+    assert_equal result.object_id, subject.object_id
+  end
+end


### PR DESCRIPTION
Here is example how to fix the sample problem to reverse words in the string.

You're working on a secret team solving coded transmissions.

Your team is scrambling to decipher a recent message, worried it's a plot to break into a major European National Cake Vault. The message has been mostly deciphered, but all the words are backward! Your colleagues have handed off the last step to you.

Write a method `reverse_words()` that takes a message as a string and reverses the order of the words in place.

For example:

    message = 'cake pound steal'
    reverse_words(message)
    puts message
    # prints: 'steal pound cake'

When writing your method, assume the message contains only letters and spaces, and all words are separated by one space.